### PR TITLE
Fix service uri test to fix issue on Xamarin

### DIFF
--- a/Common/Windows/ClientLibrary/ServiceClient.cs
+++ b/Common/Windows/ClientLibrary/ServiceClient.cs
@@ -149,9 +149,9 @@ namespace Microsoft.ProjectOxford.Common
         /// <exception cref="ClientException">Service exception</exception>
         protected async Task<TResponse> SendAsync<TRequest, TResponse>(HttpMethod method, string apiUrl, TRequest requestBody)
         {
-            bool urlIsAbsolute = System.Uri.IsWellFormedUriString(apiUrl, System.UriKind.Absolute);
+            bool urlIsRelative = System.Uri.IsWellFormedUriString(apiUrl, System.UriKind.Relative);
 
-            string requestUri = urlIsAbsolute ? apiUrl : ApiRoot + apiUrl;
+            string requestUri = urlIsRelative ? ApiRoot + apiUrl : apiUrl;
             var request = new HttpRequestMessage(method, requestUri);
             request.Headers.Add(AuthKey, AuthValue);
 


### PR DESCRIPTION
Test if url is relative (and not absolute) to bypass the behavior difference between IsWellFormedUriString in .NET and in Mono.
Discussed offline with @cthrash