### PR TITLE
Close AudioContext to fix a bug

### DIFF
--- a/Speech/Speech.JS/speech.1.0.0.js
+++ b/Speech/Speech.JS/speech.1.0.0.js
@@ -13,8 +13,8 @@
 // 
 // LICENSE
 // -------
-// © 2015 Microsoft. All rights reserved.  
-// This document is provided ìas-isî. Information and views expressed in this document, including URL and other Internet Web site references, may change without notice.  
+// ¬© 2015 Microsoft. All rights reserved.  
+// This document is provided ‚Äúas-is‚Äù. Information and views expressed in this document, including URL and other Internet Web site references, may change without notice.  
 // Some examples depicted herein are provided for illustration only and are fictitious.  No real association or connection is intended or should be inferred. 
 // This document does not provide you with any legal rights to any intellectual property in any Microsoft product. You may copy and use this document for your internal, reference purposes. This 
 // document is confidential and proprietary to Microsoft. It is disclosed and can be used only pursuant to a non-disclosure agreement. 
@@ -389,6 +389,7 @@ var Bing;
             }
         };
         Speech.prototype.stop = function () {
+            this.context.close();
             if (this._currentSource) {
                 Platform.getCU().done(function (cu) {
                     cu.disconnect();


### PR DESCRIPTION
Without closing AudioContext you can only use this api six times, otherwise you will meet "Uncaught NotSupportedError: Failed to construct ‘AudioContext’: Thenumber of hardware contexts provided (6) is greater than or equal tothe maximum bound (6)."